### PR TITLE
Enable cross compile back to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <java.version>11</java.version>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This lets us run with later Java versions, but still compile bytecode back to Java 11 compatibility