### PR TITLE
Move project to JDK 17

### DIFF
--- a/config/workload.yaml
+++ b/config/workload.yaml
@@ -6,6 +6,10 @@ metadata:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: spring-sensors
 spec:
+  build:
+    env:
+    - name: BP_JVM_VERSION
+      value: 17
   params:
     - name: annotations
       value:

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <description>Sample Spring Database Application</description>
 
     <properties>
-        <java.version>11</java.version>
-        <maven.compiler.release>11</maven.compiler.release>
+        <java.version>17</java.version>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The previous PR worked for maven compilation, but the VSCode JDK version was stepping on those changes as we run in "Standard" serverMode so that Live Updates work.  Rather than install two JDKs in an already large workshop image, I'm moving the spring sensors project to JDK 17.  This should allow us to stay current with VSCode, allow Build Service builds to work, keep users from seeing the prompt about upgrading to JDK 17, and allow live updates to function. 